### PR TITLE
adjust for the existence of natural? in racket/math

### DIFF
--- a/css/recognizer.rkt
+++ b/css/recognizer.rkt
@@ -4,7 +4,6 @@
 ;;; WARNING: Notations are not following the CSS Specifications https://drafts.csswg.org/css-values/#component-combinators
 
 (provide (all-defined-out))
-(provide (rename-out [exact-nonnegative-integer? natural?]))
 
 (require "digitama/syntax/misc.rkt")
 (require "digitama/syntax/digicore.rkt")

--- a/info.rkt
+++ b/info.rkt
@@ -5,6 +5,6 @@
 (define pkg-authors '(wargrey))
 
 (define version "1.0")
-(define deps '("base" "images-lib" "math-lib" "draw-lib" "typed-racket-lib" "typed-racket-more"))
+(define deps '(("base" #:version "6.8.0.2") "images-lib" "math-lib" "draw-lib" "typed-racket-lib" "typed-racket-more"))
 (define build-deps '("scribble-lib" "racket-doc"))
 


### PR DESCRIPTION
Somewhere in early March, the `natural?` predicate was added to `racket/math` and that causes conflicts with the way this pkg is written. This pull request fixes that so that the pkg will work with the upcoming release (and with pre-release snapshots).

Sorry for breaking your package and I hope a change along these lines is okay :(