### PR TITLE
use type-id as the type name when it is specified

### DIFF
--- a/css/digitama/color.rkt
+++ b/css/digitama/color.rkt
@@ -12,11 +12,11 @@
 (require "syntax/dimension.rkt")
 (require "../recognizer.rkt")
 
-(define-css-atomic-filter <css#color> #:-> hexa #:with [[color-value : css:hash?]]
+(define-css-atomic-filter <css#color> #:-> Hexa #:with [[color-value : css:hash?]]
   (or (css-hex-color->rgba (css:hash-datum color-value))
       (make-exn:css:range color-value))
   #:where
-  [(define (css-hex-color->rgba [hash-color : Keyword]) : (Option hexa)
+  [(define (css-hex-color->rgba [hash-color : Keyword]) : (Option Hexa)
      ;;; https://drafts.csswg.org/css-color/#numeric-rgb
      (define color : String (keyword->string hash-color))
      (define digits : Index (string-length color))


### PR DESCRIPTION
Typed Racket has a bug where struct-id can be used as the type name even when type-id is specified.
But that is not the design intention.
A new change to Typed Racket will fix the bug but break your code.

This PR should make your code forward-compatible.
Sorry for the inconvenience.